### PR TITLE
Select last pronunciation instead of the first one

### DIFF
--- a/gruut/phonemize.py
+++ b/gruut/phonemize.py
@@ -331,7 +331,7 @@ class Phonemizer:
                 (word,),
             )
             for row in cursor:
-                phonemes = row[0].split()
+                phonemes = row[-1].split()
                 if phonemes:
                     if not word_prons:
                         word_prons = []


### PR DESCRIPTION
The database is inverted, the last occurrence of the word in the DB is equal to the first occurrence of the word in wiktionary.

Most of the time, the first occurrence in wiktionary is the most used. So it's better to take the last occurence in the DB.