### PR TITLE
Fix: <sub> end_tag not properly parsed

### DIFF
--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -664,7 +664,7 @@ class TextProcessor:
                     elif end_tag == "speak":
                         # End of speak
                         last_speak = root
-                    elif end_tag == "s":
+                    elif end_tag == "sub":
                         # End of sub
                         last_alias = None
                     elif end_tag in {"metadata", "meta"}:

--- a/tests/test_ssml.py
+++ b/tests/test_ssml.py
@@ -235,7 +235,7 @@ class SSMLTestCase(unittest.TestCase):
        xsi:schemaLocation="http://www.w3.org/2001/10/synthesis
                  http://www.w3.org/TR/speech-synthesis11/synthesis.xsd"
        xml:lang="en-US">
-  <sub alias="World Wide Web Consortium">W3C</sub>
+  <sub alias="World Wide Web Consortium">W3C</sub> is an international community
   <!-- World Wide Web Consortium -->
 </speak>"""
 
@@ -247,7 +247,7 @@ class SSMLTestCase(unittest.TestCase):
 
         self.assertEqual(
             results,
-            [(0, 0, "World"), (0, 1, "Wide"), (0, 2, "Web"), (0, 3, "Consortium")],
+            [(0, 0, "World"), (0, 1, "Wide"), (0, 2, "Web"), (0, 3, "Consortium"), (0, 4, "is"), (0, 5, "an"), (0, 6, "international"), (0, 7, "community")],
         )
 
     def test_lang_element(self):


### PR DESCRIPTION
Fixed a typo that was preventing the `<sub>` tag from properly parsing

Also added some extra data to the `<sub>` test case