### PR TITLE
Fix first usage exemple documentation

### DIFF
--- a/docs/_sources/index.rst.txt
+++ b/docs/_sources/index.rst.txt
@@ -12,8 +12,9 @@ A tokenizer and `IPA <https://en.wikipedia.org/wiki/International_Phonetic_Alpha
     text = 'He wound it around the wound, saying "I read it was $10 to read."'
 
     for sent in sentences(text, lang="en-us"):
-        if word.phonemes:
-            print(word.text, *word.phonemes)
+        for word in sent:
+            if word.phonemes:
+                print(word.text, *word.phonemes)
 
 Output::
 


### PR DESCRIPTION
It seems a `for word in sent:` was forgotten :)