### PR TITLE
Bump dateparser to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel>=2.8.0,<3.0.0
-dateparser~=1.1.0
+dateparser~=1.1.1
 gruut-ipa>=0.12.0,<1.0
 gruut_lang_en~=2.0.0
 jsonlines~=1.2.0


### PR DESCRIPTION
dateparser 1.1.0 has a nasty bug that's [fixed in 1.1.1](https://github.com/scrapinghub/dateparser/releases/tag/v1.1.1)