### PR TITLE
Fix paragraph ending

### DIFF
--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -772,8 +772,9 @@ class TextProcessor:
                         # End of sentence
                         last_sentence = None
                     elif end_tag == "p":
-                        # End of paragraph
+                        # End of paragraph and sentence
                         last_paragraph = None
+                        last_sentence = None
                     elif end_tag == "speak":
                         # End of speak
                         last_speak = root


### PR DESCRIPTION
End last sentence as well while ending a paragraph. Currently the last sentence does not end which causes words from next paragraphs to be included in the sentence from previous paragraph.

For the following example code:
```
from gruut import sentences

ssml_text = """<?xml version="1.0" encoding="ISO-8859-1"?>
<speak>
    This is 1st paragraph.
    <p>This is 2nd.</p>
    This must be third... Right?
</speak>"""

for sent in sentences(ssml_text, ssml=True):
    print(sent.par_idx, sent.idx, sent.text)
```

Old output:
```
0 0 This is first paragraph.
1 0 This is second.
1 1 This must be third... Right?
```
New output:
```
0 0 This is first paragraph.
1 0 This is second.
2 0 This must be third... Right?
```