### PR TITLE
Added 'and' between dollars and cents. Also added prosody rate support

### DIFF
--- a/gruut/const.py
+++ b/gruut/const.py
@@ -308,6 +308,7 @@ class WordNode(Node):
     text_with_ws: str = ""
     interpret_as: typing.Union[str, InterpretAs] = ""
     format: typing.Union[str, InterpretAsFormat] = ""
+    rate: str = ""
 
     number: typing.Optional[Decimal] = None
     date: typing.Optional[datetime] = None

--- a/gruut/const.py
+++ b/gruut/const.py
@@ -404,6 +404,9 @@ class Word:
     voice: str = ""
     """Voice (from SSML)"""
 
+    rate: str = ""
+    """Prosody rate from SSML"""
+
     pos: typing.Optional[str] = None
     """Part of speech (None if not set)"""
 
@@ -471,6 +474,9 @@ class Sentence:
 
     voice: str = ""
     """Voice (from SSML)"""
+
+    rate: str = ""
+    """Prosody rate (from SSML)"""
 
     words: typing.List[Word] = field(default_factory=list)
     """Words in the sentence"""

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -370,7 +370,28 @@ class TextProcessor:
                 w.text for w in sentence.words if w.is_spoken
             )
 
-            # Normalize voice
+            # Normalize rate
+            sent_rate = sentence.rate
+
+            # Get rate used across all words
+            for word in sentence.words:
+                if word.rate:
+                    if sent_rate and (sent_rate != word.rate):
+                        # Multiple rates
+                        sent_rate = ""
+                        break
+
+                    sent_rate = word.rate
+
+            if sent_rate:
+                sentence.rate = sent_rate
+
+                # Set rate on all words
+                for word in sentence.words:
+                    word.rate = sent_rate
+
+
+            # Normalize rate
             sent_voice = sentence.voice
 
             # Get voice used across all words

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -2379,7 +2379,7 @@ class TextProcessor:
         num2words_kwargs["currency"] = word.currency_name
 
         # Custom separator so we can remove 'zero cents'
-        num2words_kwargs["separator"] = " and"
+        num2words_kwargs["separator"] = "|"
 
         try:
             num_str = num2words(float(decimal_num), **num2words_kwargs)
@@ -2392,7 +2392,7 @@ class TextProcessor:
         # Post-process currency words
         if num_has_frac:
             # Discard num2words separator
-            num_str = num_str.replace("|", "and")
+            num_str = num_str.replace("|", " and")
         else:
             # Remove 'zero cents' part
             num_str = num_str.split("|", maxsplit=1)[0]

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -2393,6 +2393,7 @@ class TextProcessor:
         if num_has_frac:
             # Replace num2words separator with and
             num_str = num_str.replace("|", " and")
+            num_str = num_str.replace(" and ", " ", num_str.count(" and ") - 1)  # Only the last "and" is retained
         else:
             # Remove 'zero cents' part
             num_str = num_str.split("|", maxsplit=1)[0]

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -554,14 +554,14 @@ class TextProcessor:
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
 
-            if prosody_stack:
-                scope["rate"] = prosody_stack[-1]
-
             scope["lang"] = current_lang
 
             if target_class is WordNode:
                 if say_as_stack:
                     scope["interpret_as"], scope["format"] = say_as_stack[-1]
+
+                if prosody_stack:
+                    scope["rate"] = prosody_stack[-1]
 
                 if word_role is not None:
                     scope["role"] = word_role

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -2390,10 +2390,12 @@ class TextProcessor:
             return
 
         # Post-process currency words
-        if not num_has_frac:
+        if num_has_frac:
+            # Discard num2words separator
+            num_str = num_str.replace("|", "and")
+        else:
             # Remove 'zero cents' part
-            num_str_split = num_str.split(" and")
-            num_str = num_str.replace('and' + num_str_split[len(num_str_split) - 1], "")
+            num_str = num_str.split("|", maxsplit=1)[0]
 
         # Add original whitespace back in
         first_ws, last_ws = settings.get_whitespace(word.text_with_ws)

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -212,7 +212,6 @@ class TextProcessor:
                                 is_major_break=is_major_break,
                                 lang=get_lang(node.lang),
                                 voice=node.voice,
-                                rate=node.voice,
                                 pause_before_ms=word_pause_before_ms,
                                 marks_before=(
                                     word_marks_before if word_marks_before else None

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -554,14 +554,15 @@ class TextProcessor:
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
 
+            if prosody_stack:
+                scope["prosody"] = prosody_stack[-1]
+
             scope["lang"] = current_lang
 
             if target_class is WordNode:
                 if say_as_stack:
                     scope["interpret_as"], scope["format"] = say_as_stack[-1]
 
-                if prosody_stack:
-                    scope["rate"] = prosody_stack[-1]
 
                 if word_role is not None:
                     scope["role"] = word_role

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -2379,7 +2379,7 @@ class TextProcessor:
         num2words_kwargs["currency"] = word.currency_name
 
         # Custom separator so we can remove 'zero cents'
-        num2words_kwargs["separator"] = "|"
+        num2words_kwargs["separator"] = " and"
 
         try:
             num_str = num2words(float(decimal_num), **num2words_kwargs)
@@ -2390,12 +2390,10 @@ class TextProcessor:
             return
 
         # Post-process currency words
-        if num_has_frac:
-            # Discard num2words separator
-            num_str = num_str.replace("|", "")
-        else:
+        if not num_has_frac:
             # Remove 'zero cents' part
-            num_str = num_str.split("|", maxsplit=1)[0]
+            num_str_split = num_str.split(" and")
+            num_str = num_str.replace('and' + num_str_split[len(num_str_split) - 1], "")
 
         # Add original whitespace back in
         first_ws, last_ws = settings.get_whitespace(word.text_with_ws)

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -515,6 +515,9 @@ class TextProcessor:
         # [voice]
         voice_stack: typing.List[str] = []
 
+        # [rate]
+        prosody_stack: typing.List[str] = []
+
         # [(interpret_as, format)]
         say_as_stack: typing.List[typing.Tuple[str, str]] = []
 
@@ -550,6 +553,9 @@ class TextProcessor:
             scope = {}
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
+
+            if prosody_stack:
+                scope["rate"] = prosody_stack[-1]
 
             scope["lang"] = current_lang
 
@@ -707,6 +713,9 @@ class TextProcessor:
                 elif end_tag == "say-as":
                     if say_as_stack:
                         say_as_stack.pop()
+                elif end_tag == "prosody":
+                    if prosody_stack:
+                        prosody_stack.pop()
                 elif end_tag == "lookup":
                     if lookup_stack:
                         lookup_stack.pop()
@@ -920,6 +929,9 @@ class TextProcessor:
                             attrib_no_namespace(elem, "format", ""),
                         )
                     )
+                elif elem_tag == "prosody":
+                    prosody_rate = attrib_no_namespace(elem, "rate", "1")
+                    prosody_stack.append(prosody_rate)
                 elif elem_tag == "sub":
                     # Sub
                     last_alias = attrib_no_namespace(elem, "alias", "")

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -2391,7 +2391,7 @@ class TextProcessor:
 
         # Post-process currency words
         if num_has_frac:
-            # Discard num2words separator
+            # Replace num2words separator with and
             num_str = num_str.replace("|", " and")
         else:
             # Remove 'zero cents' part

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -174,6 +174,7 @@ class TextProcessor:
                             pos=word_node.pos if pos else None,
                             lang=get_lang(node.lang),
                             voice=node.voice,
+                            rate=node.rate,
                             pause_before_ms=word_pause_before_ms,
                             marks_before=(
                                 word_marks_before if word_marks_before else None
@@ -211,6 +212,7 @@ class TextProcessor:
                                 is_major_break=is_major_break,
                                 lang=get_lang(node.lang),
                                 voice=node.voice,
+                                rate=node.voice,
                                 pause_before_ms=word_pause_before_ms,
                                 marks_before=(
                                     word_marks_before if word_marks_before else None

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -554,15 +554,14 @@ class TextProcessor:
             if voice_stack:
                 scope["voice"] = voice_stack[-1]
 
-            if prosody_stack:
-                scope["prosody"] = prosody_stack[-1]
-
             scope["lang"] = current_lang
 
             if target_class is WordNode:
                 if say_as_stack:
                     scope["interpret_as"], scope["format"] = say_as_stack[-1]
 
+                if prosody_stack:
+                    scope["rate"] = prosody_stack[-1]
 
                 if word_role is not None:
                     scope["role"] = word_role

--- a/gruut/text_processor.py
+++ b/gruut/text_processor.py
@@ -390,7 +390,7 @@ class TextProcessor:
                     word.rate = sent_rate
 
 
-            # Normalize rate
+            # Normalize voice
             sent_voice = sentence.voice
 
             # Get voice used across all words


### PR DESCRIPTION
Currently, gruut converts a currency value like $10034.54 into 'ten thousand and thirty-four dollars fifty-four cents'.
This has now been corrected to be 'ten thousand thirty-four dollars and fifty-four cents'.
There is now an 'and' between the dollars and cents.
Also all the 'and's except the last one are removed if there is a cents portion (the "and" between thousand and thirty).

Also added prosody